### PR TITLE
Automate jacocco HTML report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,9 @@
         <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
         <aerogear.security.version>1.2.1</aerogear.security.version>
         <aerogear.security.picketlink.version>1.2.2</aerogear.security.picketlink.version>
+        <org.jacoco.ant.version>0.6.3.201306030806</org.jacoco.ant.version>
+        <org.jacoco.agent.version>0.6.3.201306030806</org.jacoco.agent.version>
+        <ant.contrib.version>20020829</ant.contrib.version>
     </properties>
 
     <dependencyManagement>
@@ -268,7 +271,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>as711-managed</id>
@@ -364,7 +367,12 @@
 
         <profile>
             <id>code-coverage</id>
-
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-arquillian-container-managed</artifactId>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -392,7 +400,7 @@
                                         <artifactItem>
                                             <groupId>org.jacoco</groupId>
                                             <artifactId>org.jacoco.agent</artifactId>
-                                            <version>0.6.3.201306030806</version>
+                                            <version>${org.jacoco.agent.version}</version>
                                             <type>jar</type>
                                             <overWrite>true</overWrite>
                                             <outputDirectory>${project.build.directory}</outputDirectory>
@@ -403,21 +411,90 @@
                         </executions>
                     </plugin>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.7</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.ant</artifactId>
+                                <version>${org.jacoco.ant.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>ant-contrib</groupId>
+                                <artifactId>ant-contrib</artifactId>
+                                <version>${ant.contrib.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>jacoco-report</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <property name="source-folder" location="${project.basedir}/aerogear-unifiedpush-server" />
+                                        <taskdef name="jacoco-report" classname="org.jacoco.ant.ReportTask"
+                                            classpathref="maven.plugin.classpath" />
+                                        <taskdef classpathref="maven.runtime.classpath" resource="net/sf/antcontrib/antcontrib.properties" />
+                                        <available file="${project.basedir}/${jacoco.report.file}" property="exec.file.exists" />
+                                        <echo message="${project.basedir}/${jacoco.report.file}" />
+                                        <echo message="${source-folder}" />
+                                        <if>
+                                            <equals arg1="${exec.file.exists}" arg2="true" />
+                                            <then>
+                                                <trycatch reference="report_exception">
+                                                    <try>
+                                                        <jacoco-report>
+                                                            <executiondata>
+                                                                <file file="${project.basedir}/${jacoco.report.file}" />
+                                                            </executiondata>
+                                                            <structure name="Aerogear">
+                                                                <classfiles>
+                                                                    <fileset dir="${source-folder}/target/classes" />
+                                                                </classfiles>
+                                                                <sourcefiles encoding="UTF-8">
+                                                                    <fileset dir="${source-folder}/src/main" />
+                                                                </sourcefiles>
+                                                            </structure>
+                                                            <html destdir="${project.basedir}/target/jacoco/report" />
+                                                        </jacoco-report>
+                                                    </try>
+                                                    <catch>
+                                                        <property name="exception" refid="report_exception" />
+                                                        <property name="message"
+                                                            value="Error while generating jacoco report: ${exception}" />
+                                                        <echo message="${message}" />
+                                                    </catch>
+                                                </trycatch>
+                                            </then>
+                                            <else>
+                                                <echo message="${project.basedir}/${jacoco.report.file} .exec file is missing." />
+                                            </else>
+                                        </if>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
                                 <!-- As for excludes, there is something wrong in EJB 3.1 implementation in JBoss AS 7 - https://groups.google.com/forum/#!topic/jacoco/9TlsMdRE_10 -->
                                 <arq.container.jboss.configuration.javaVmArguments>
-                                    -Djboss.bind.address=127.0.0.1 -Xmx512m -XX:MaxPermSize=512m -javaagent:${project.build.directory}/jacocoagent.jar=append=true,destfile=${jacoco.report.file},excludes=*$$$$$$*
+                                    -Djboss.bind.address=127.0.0.1 -Xmx512m
+                                    -XX:MaxPermSize=512m
+                                    -javaagent:${project.build.directory}/jacocoagent.jar=append=true,destfile=${jacoco.report.file},excludes=*$$$$$$*
                                 </arq.container.jboss.configuration.javaVmArguments>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
-
         </profile>
-
     </profiles>
 
     <repositories>


### PR DESCRIPTION
mvn clean package -P code-coverage -Djacoco.report.file=target/jacocco.exec creates a jacoco HTML report after the tests execution. Current total test coverage is 84%
