### PR TITLE
Use UPS sender client truststore support feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_install:
  - ./setup/setup.sh
  - export JBOSS_HOME=`pwd`/jboss-as-7.1.1.Final
 script:
- - mvn test -Djavax.net.ssl.trustStore="setup/aerogear.truststore" -Djavax.net.ssl.trustStorePassword=aerogear
+ - mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 
         <org.jboss.spec.javaee6.version>3.0.2.Final</org.jboss.spec.javaee6.version>
 
+	<org.jboss.aerogear.upsjavaclient.version>0.6.0</org.jboss.aerogear.upsjavaclient.version>
 
         <!-- Testing -->
         <org.jboss.shrinkwrap.resolver>2.0.2</org.jboss.shrinkwrap.resolver>
@@ -159,7 +160,7 @@
         <dependency>
             <groupId>org.jboss.aerogear</groupId>
             <artifactId>unifiedpush-java-client</artifactId>
-            <version>0.5.0</version>
+            <version>${org.jboss.aerogear.upsjavaclient.version}</version>
         </dependency>
 
         <!-- Test stuff -->

--- a/src/test/java/org/jboss/aerogear/unifiedpush/utils/PushNotificationSenderUtils.java
+++ b/src/test/java/org/jboss/aerogear/unifiedpush/utils/PushNotificationSenderUtils.java
@@ -61,8 +61,10 @@ public final class PushNotificationSenderUtils {
 
     public static void send(UnifiedMessage message, Session session) {
 
-        JavaSender sender = new SenderClient(session.getBaseUrl().toExternalForm());
-
+        SenderClient sender = new SenderClient.Builder().rootServerURL(session.getBaseUrl().toExternalForm())
+                .customTrustStore("setup/aerogear.truststore", null, "aerogear")
+                .build();
+        
         final CountDownLatch latch = new CountDownLatch(1);
         final List<Integer> returnedStatusList = new ArrayList<Integer>(1);
         final AtomicBoolean onFailCalled = new AtomicBoolean(false);


### PR DESCRIPTION
After AGPUSH-559 is accepted and the new version of ups-java-client is released, the sender can be configured by using a custom truststore.
