### PR TITLE
Setup truststore to be passed as JVM parameter

### DIFF
--- a/setup/configure_truststore_domain.cli
+++ b/setup/configure_truststore_domain.cli
@@ -1,0 +1,5 @@
+connect
+batch
+/system-property="javax.net.ssl.trustStore":add(value="{jboss.server.dir}/domain/configuration/aerogear.truststore")
+/system-property="javax.net.ssl.trustStorePassword":add(value=aerogear)
+run-batch

--- a/setup/configure_truststore_standalone.cli
+++ b/setup/configure_truststore_standalone.cli
@@ -1,0 +1,5 @@
+connect
+batch
+/system-property="javax.net.ssl.trustStore":add(value="{jboss.server.dir}/standalone/configuration/aerogear.truststore")
+/system-property="javax.net.ssl.trustStorePassword":add(value=aerogear)
+run-batch

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -189,6 +189,13 @@ JBOSS_HOME=$JBOSS_AS_HOME
 patchContainer $JBOSS_AS_HOME standalone $SCRIPT_DIR/enable_https.cli 7
 patchContainer $JBOSS_AS_HOME domain $SCRIPT_DIR/enable_https_domain.cli 7
 
+# configure JVM parameters to use our truststore
+sed -i "s@{jboss.server.dir}@$JBOSS_HOME@g" $SCRIPT_DIR/configure_truststore_standalone.cli
+sed -i "s@{jboss.server.dir}@$JBOSS_HOME@g" $SCRIPT_DIR/configure_truststore_domain.cli
+
+patchContainer $JBOSS_HOME standalone $SCRIPT_DIR/configure_truststore_standalone.cli 7
+patchContainer $JBOSS_HOME domain $SCRIPT_DIR/configure_truststore_domain.cli 7
+
 JBOSS_HOME=$WILDFLY_HOME
 patchContainer $WILDFLY_HOME standalone $SCRIPT_DIR/enable_https_wildfly.cli 7
 patchContainer $WILDFLY_HOME domain $SCRIPT_DIR/enable_https_domain_wildfly_add_sslrealm.cli 7


### PR DESCRIPTION
We want to configure our truststore as a JVM parameter passed to the server so that applications deployed on it can use this truststore for server's certificate verification.

We will use it in tests.
