### PR TITLE
Add Java Sender KeyStore sharing test

### DIFF
--- a/src/test/java/org/jboss/aerogear/test/api/sender/PushMessageInformationRequest.java
+++ b/src/test/java/org/jboss/aerogear/test/api/sender/PushMessageInformationRequest.java
@@ -1,0 +1,49 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.test.api.sender;
+
+import java.util.List;
+
+import org.jboss.aerogear.test.ContentTypes;
+import org.jboss.aerogear.test.Headers;
+import org.jboss.aerogear.test.api.AbstractSessionRequest;
+import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+
+import com.jayway.restassured.path.json.JsonPath;
+import com.jayway.restassured.response.Response;
+
+/** 
+ *  Request for retreiving Push Message Information
+ */
+public class PushMessageInformationRequest extends AbstractSessionRequest<PushMessageInformationRequest> {
+
+    public List<PushMessageInformation> get(String applicationId) {
+        
+        Response response = getSession().givenAuthorized()
+                .contentType(ContentTypes.json())
+                .header(Headers.acceptJson())
+                .get("http://localhost:8080/ag-push/rest/metrics/messages/application/" + applicationId);
+        
+        String json = response.asString();
+        return JsonPath.from(json).get("");
+    }
+    
+    public static PushMessageInformationRequest request() {
+        return new PushMessageInformationRequest();
+    }
+    
+}

--- a/src/test/java/org/jboss/aerogear/unifiedpush/test/Deployments.java
+++ b/src/test/java/org/jboss/aerogear/unifiedpush/test/Deployments.java
@@ -21,6 +21,7 @@ import com.google.android.gcm.server.MulticastResult;
 import com.google.android.gcm.server.Result;
 import com.google.android.gcm.server.Sender;
 import com.notnoop.apns.internal.ApnsServiceImpl;
+
 import org.arquillian.spacelift.execution.ExecutionException;
 import org.arquillian.spacelift.execution.Tasks;
 import org.arquillian.spacelift.process.ProcessInteractionBuilder;
@@ -28,6 +29,8 @@ import org.arquillian.spacelift.process.impl.CommandTool;
 import org.jboss.aerogear.test.api.installation.Tokens;
 import org.jboss.aerogear.test.api.sender.SenderStatistics;
 import org.jboss.aerogear.unifiedpush.message.sender.GCMForChromePushNotificationSender;
+import org.jboss.aerogear.unifiedpush.utils.JavaSenderTestEndpoint;
+import org.jboss.aerogear.unifiedpush.utils.JavaSenderTestRestApplication;
 import org.jboss.aerogear.unifiedpush.utils.SenderStatisticsEndpoint;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.Filter;
@@ -63,6 +66,7 @@ public final class Deployments {
 
     public static final String AG_PUSH = "ag_push";
     public static final String AUTH_SERVER = "auth_server";
+    public static final String JAVA_CLIENT = "java_client";
 
     private static final String PROPERTY_UPS_SOURCE = "ups.source";
     private static final String PROPERTY_UPS_VERSION = "ups.version";
@@ -443,6 +447,21 @@ public final class Deployments {
         }
     }
 
+    /**
+     * Returns REST web application that uses Java Client
+     * to test push using the same trust store
+     */
+    public static WebArchive javaSenderTest() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "javaSender.war");
+        war.addClass(JavaSenderTestEndpoint.class);
+        war.addClass(JavaSenderTestRestApplication.class);
+        
+        File[] javaSenderJAR = Maven.resolver().resolve("org.jboss.aerogear:unifiedpush-java-client:0.8.0").withTransitivity().asFile();
+        war.addAsLibraries(javaSenderJAR);
+        
+        return war;
+    }
+    
     /**
      * Returns an array of profile names for maven build. This is currently only to pass in code-coverage profile for
      * ups build.

--- a/src/test/java/org/jboss/aerogear/unifiedpush/test/JavaSenderKeyStoreSharingTest.java
+++ b/src/test/java/org/jboss/aerogear/unifiedpush/test/JavaSenderKeyStoreSharingTest.java
@@ -1,0 +1,117 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.test;
+
+import java.util.List;
+
+import org.jboss.aerogear.arquillian.junit.ArquillianRule;
+import org.jboss.aerogear.arquillian.junit.ArquillianRules;
+import org.jboss.aerogear.test.api.application.PushApplicationWorker;
+import org.jboss.aerogear.test.api.sender.PushMessageInformationRequest;
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+import org.jboss.aerogear.unifiedpush.utils.Constants;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.config.DecoderConfig;
+import com.jayway.restassured.config.EncoderConfig;
+import com.jayway.restassured.config.RestAssuredConfig;
+
+import static org.junit.Assert.*;
+import static com.jayway.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(ArquillianRules.class)
+public class JavaSenderKeyStoreSharingTest {
+
+    @ArquillianRule
+    public static UnifiedPushServer ups = new UnifiedPushServer() {
+        @Override
+        protected UnifiedPushServer setup() {
+            ups.with(PushApplicationWorker.worker()).generate().persist();
+            return this;
+        }
+    };
+    
+    @After
+    public void cleanPushApplications() {
+        ups.with(PushApplicationWorker.worker()).findAll().removeAll();
+    }
+
+    @BeforeClass
+    public static void setup() {
+        RestAssured.config = RestAssuredConfig.newConfig()
+                .decoderConfig(DecoderConfig.decoderConfig().defaultContentCharset("UTF-8"))
+                .encoderConfig(EncoderConfig.encoderConfig().defaultContentCharset("UTF-8"));
+
+        RestAssured.keystore(Constants.KEYSTORE_PATH, Constants.KEYSTORE_PASSWORD);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        RestAssured.config = RestAssuredConfig.newConfig()
+                .decoderConfig(DecoderConfig.decoderConfig().defaultContentCharset("ISO-8859-1"))
+                .encoderConfig(EncoderConfig.encoderConfig().defaultContentCharset("ISO-8859-1"));
+    }
+
+    @Deployment(name = Deployments.AUTH_SERVER, testable = false, order = 1)
+    @TargetsContainer("main-server-group")
+    public static WebArchive createAuthServerDeployment() {
+        return Deployments.authServer();
+    }
+
+    @Deployment(name = Deployments.AG_PUSH, testable = false, order = 2)
+    @TargetsContainer("main-server-group")
+    public static WebArchive createDeployment() {
+        return Deployments.unifiedPushServerWithCustomSenders();
+    }
+    
+    @Deployment(name = Deployments.JAVA_CLIENT, testable = false, order = 3)
+    @TargetsContainer("main-server-group")
+    public static WebArchive createJavaClientTestDeployment() {
+       return Deployments.javaSenderTest();
+    }
+    
+    private PushApplication getPushApp() {
+        return ups.with(PushApplicationWorker.worker()).findAll().detachEntity();
+    }
+    
+    @Test
+    public void javaSenderSharesKeystoreWithPushApplicationOnSameJvm() throws InterruptedException {
+        String appId = getPushApp().getPushApplicationID();
+        String secret = getPushApp().getMasterSecret();
+        
+        // send message
+        given().formParameters("pushAppId", appId, "secret", secret)
+            .post("http://localhost:8080/javaSender/rest/javaSenderTest")
+            .body().asString().equals("Message sent!");
+        
+        // check that the message was sent
+        List<PushMessageInformation> pmi = ups.with(PushMessageInformationRequest.request()).get(appId);
+        
+        assertThat(pmi, is(not(empty())));
+    }
+    
+}

--- a/src/test/java/org/jboss/aerogear/unifiedpush/utils/JavaSenderTestEndpoint.java
+++ b/src/test/java/org/jboss/aerogear/unifiedpush/utils/JavaSenderTestEndpoint.java
@@ -1,0 +1,53 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.utils;
+
+import javax.ejb.Stateless;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.aerogear.unifiedpush.JavaSender;
+import org.jboss.aerogear.unifiedpush.SenderClient;
+import org.jboss.aerogear.unifiedpush.message.UnifiedMessage;
+
+/**
+ * End-point for {@link JavaSenderKeyStoreSharingTest}
+ */
+@Stateless
+@Path("/javaSenderTest")
+public class JavaSenderTestEndpoint {
+
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String sendPushMessage(@FormParam("pushAppId") String appId, @FormParam("secret") String secret) {
+        JavaSender defaultJavaSender = new SenderClient.Builder("https://localhost:8443/ag-push").build();
+        
+        UnifiedMessage unifiedMessage = new UnifiedMessage.Builder()
+            .pushApplicationId(appId)
+            .masterSecret(secret)
+            .alert("Hello from Java Sender API!")
+            .build();
+        
+        defaultJavaSender.send(unifiedMessage);
+        
+        return "Message sent!";
+    }
+    
+}

--- a/src/test/java/org/jboss/aerogear/unifiedpush/utils/JavaSenderTestRestApplication.java
+++ b/src/test/java/org/jboss/aerogear/unifiedpush/utils/JavaSenderTestRestApplication.java
@@ -1,0 +1,33 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.utils;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * The JAX-RS {@link Application} representing the base
+ * entry point for all RESTful HTTP requests of Java sender test app.
+ */
+@ApplicationPath("/rest")
+public class JavaSenderTestRestApplication extends Application {
+
+    public JavaSenderTestRestApplication() {
+        
+    }
+    
+}


### PR DESCRIPTION
This test is using Java Sender to send a push message to UPS and verifies that the message was sent. It proves that the Aerogear's truststore can be used to verify server's certificate from the keystore.

This test will only work when truststore is set as a JVM parameter.
